### PR TITLE
Bump org.eclipse.persistence.jpa.modelgen.processor from 2.7.12 to 3.0.3

### DIFF
--- a/jakarta-ee/jee-examples/pom.xml
+++ b/jakarta-ee/jee-examples/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>org.eclipse.persistence.jpa.modelgen.processor</artifactId>
-            <version>2.7.12</version>
+            <version>3.0.3</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Bumps org.eclipse.persistence.jpa.modelgen.processor from 2.7.12 to 3.0.3.

---
updated-dependencies:
- dependency-name: org.eclipse.persistence:org.eclipse.persistence.jpa.modelgen.processor dependency-type: direct:production update-type: version-update:semver-major ...