### PR TITLE
enh: split up DAO API from implementation

### DIFF
--- a/docs/content/flowlogix.adoc
+++ b/docs/content/flowlogix.adoc
@@ -82,8 +82,8 @@ See the link:https://maven.apache.org/guides/introduction/introduction-to-depend
 == Developer's Guide
 [[section-jee]]
 === FlowLogix Jakarta EE Components
-[[section-daohelper]]
-==== `JPAFinder` for JPA: Delegation-based Helper for Data Access Objects and business logic
+[[section-jpafinder]]
+==== `JPAFinder` for JPA: Delegation-based Enhanced Queries for Data Access Objects and business logic
 .Enhanced Finder and count methods
 `findAll()`, `findRange()` and `count()` take an optional argument to enhance the queries, which can add additional JPA clauses, enhancements and hints. This parameter takes a form of `QueryEnhancement` interface, which extends `BiConsumer` interface. There are a number of `accept` convenience methods in  `QueryEnhancement` interface that can be passed via a method reference.
 [source,java]
@@ -116,7 +116,7 @@ _Fluent Builder_ pattern can be used to create `DaoHelper` object, which require
 That's Because `EntityManager` is not initialized when the object is created. `Supplier` lets you delay the initialization of `DaoHelper` until `EntityManager` is actually needed at run-time and is already initialized. This is why `InheritableDAOHelper` needs to be initialized in `@PostConstruct` method instead of the constructor.
 
 .Where are `find()` and related methods?
-These methods are built into the EntityManager and can be accessed that way (see the "more complete" example below). There is no need for DaoHelper to provide them. If more functionality related to `find()` is desired, https://deltaspike.apache.org[Apache DeltaSpike^] project is a wonderful addition to your architecture and will satisfy those needs.
+These methods are built into the EntityManager and can be accessed that way (see the "more complete" example below). There is no need for JPAFinder to provide them. If more functionality related to `find()` is desired, Jakarta Data or https://deltaspike.apache.org[Apache DeltaSpike^] project is a wonderful addition to your architecture and will satisfy those needs.
 
 https://github.com/flowlogix/flowlogix/tree/main/jakarta-ee/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao[Full Demos on GitHub^]
 
@@ -170,7 +170,7 @@ include::../../jakarta-ee/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/
 
 [[section-nativequery]]
 ==== JPA: Generics-based Type-safe native query
-`DaoHelper` has a convenience method `createNativeQuery()` which will return `TypedNativeQuery` object. This is a thin wrapper over JPA's `Query` object, however it's `getResult*()` methods return typed results via generics, which avoids casting and makes the results easier and safer to use.
+`JPANativeQuery` interface has a convenience method `createNativeQuery()` which will return `TypedNativeQuery` object. This is a thin wrapper over JPA's `Query` object, however it's `getResult*()` methods return typed results via generics, which avoids casting and makes the results easier and safer to use.
 [source,java]
 .Native Query Example
 ----
@@ -371,7 +371,7 @@ Developers can transform any XML file from the archive by using the generic `man
 [[section-jpa-lazymodel]]
 === FlowLogix PrimeFaces DataTable Lazy Data Model backed by JPA
 .An easier alternative to PrimeFaces JPA Lazy Data model
-PrimeFaces provides a convenient https://www.javadoc.io/doc/org.primefaces/primefaces/latest/org/primefaces/model/JpaLazyDataModel.html[wrapper^] for the Lazy DataModel. However, FlowLogix `JPALazyDataModel` predates it and therefore has a big "head start" in ease of use, features and compactness. Biggest advantage is ability to `@Inject` the model via CDI. The model utilizes `DaoHelper` classes and methodology to make JPA lazy data model easier to use, with a lot less code and better design. The model not require inheritance and problems associated with it. In addition to its ease of use advantages, `JPALazyDataModel` is fully serializable, making its use trivial in clustered sessions, like the ones in Payara and Hazelcast. To make it even easier to use and configure, model's initialization lambdas do not have to be serializable and 'just work' out-of-the-box without paying any special attention to their context.
+PrimeFaces provides a convenient https://www.javadoc.io/doc/org.primefaces/primefaces/latest/org/primefaces/model/JpaLazyDataModel.html[wrapper^] for the Lazy DataModel. However, FlowLogix `JPALazyDataModel` predates it and therefore has a big "head start" in ease of use, features and compactness. Biggest advantage is ability to `@Inject` the model via CDI. The model utilizes `JPAFinder` classes and methodology to make JPA lazy data model easier to use, with a lot less code and better design. The model not require inheritance and problems associated with it. In addition to its ease of use advantages, `JPALazyDataModel` is fully serializable, making its use trivial in clustered sessions, like the ones in Payara and Hazelcast. To make it even easier to use and configure, model's initialization lambdas do not have to be serializable and 'just work' out-of-the-box without paying any special attention to their context.
 [source,xhtml]
 .userviewer.xhtml
 ----
@@ -411,7 +411,7 @@ During direct creation, `JPALazyDataModel` only requires `entityClass` to work, 
 * wildcardSupport: Specifies whether wildcards are supported in `EXACT` and other String queries (boolean). Default is false.
 * sorter: Apply additional or replacement sort criteria
 * filter: Apply additional or replacement filter criteria
-* optimizer: Apply additional customizations to queries, such as JPA hints, works together with `DaoHelper`
+* optimizer: Apply additional customizations to queries, such as JPA hints, works together with `JPAFinder`
 * converter: `Function` that converts String representation of a primary key into a primary key object. Needed only if the default is insufficient.
 * keyConverter: `Function` that converts an entity object into it's primary key in `String` form. Needed only if the default is insufficient.
 

--- a/docs/content/flowlogix.adoc
+++ b/docs/content/flowlogix.adoc
@@ -99,16 +99,16 @@ include::../../jakarta-ee/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/
 ----
 https://github.com/flowlogix/flowlogix/tree/main/jakarta-ee/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/UserDAO.java[Full Demo on GitHub^]
 
-There are many ways to implement the Data-Access-Object pattern in Java. Most of them require to implement an interface, have some kind of bytecode generation magic or inherit from a base class. FlowLogix takes a different approach. The amount of magic is totally up to the developers. If none of the below approaches work, your DAO can simply inherit from `InheritableDaoHelper`, and initialize the `daoHelper` protected field in your `@PostConstruct` method.
+There are many ways to implement the Data-Access-Object pattern in Java. Most of them require to implement an interface, have some kind of bytecode generation magic or inherit from a base class. FlowLogix takes a different approach. The amount of magic is totally up to the developers. If none of the below approaches work, your DAO can simply inherit from `InheritableDaoHelper`, and initialize the `jpaFinder` protected field in your `@PostConstruct` method.
 
 You can leverage Project Lombok @Delegate annotation to transparently implement Data Access Objects without any specific requirements. Alternatively, developers can write manual forwarder methods, dynamic proxies, or
-other bytecode generators to delegate to `DaoHelper` from an interface.
+other bytecode generators to delegate to `JPAFinder` from an interface.
 
 Recommended approach is to use Lombok's `@Delegate` annotation. This introduces the fewest amount of magic, results in the least amount of code, and absolute minimum (if any) boilerplate.
 
-`DaoHelper` can also be `@Inject` ed and it will infer the `EntityManager` via CDI. If default CDI producer for the EntityManager is insufficient, `@EntityManagerSelector` annotation can be used to specify qualifiers for non-default `EntityManager` producer
+`JPAFinder` can also be `@Inject` ed and it will infer the `EntityManager` via CDI. If default CDI producer for the EntityManager is insufficient, `@EntityManagerSelector` annotation can be used to specify qualifiers for non-default `EntityManager` producer
 
-`DaoHelper` is Serializable and thus can be used inside `@ViewScoped` beans, for example.
+`JPAFinder` is Serializable and thus can be used inside `@ViewScoped` beans, for example.
 
 _Fluent Builder_ pattern can be used to create `DaoHelper` object, which requires EntityManager `Supplier` and entity `Class`.
 

--- a/docs/content/flowlogix.adoc
+++ b/docs/content/flowlogix.adoc
@@ -83,9 +83,9 @@ See the link:https://maven.apache.org/guides/introduction/introduction-to-depend
 [[section-jee]]
 === FlowLogix Jakarta EE Components
 [[section-daohelper]]
-==== `DaoHelper` for JPA: Delegation-based Helper for Data Access Objects and business logic
+==== `JPAFinder` for JPA: Delegation-based Helper for Data Access Objects and business logic
 .Enhanced Finder and count methods
-`findAll()`, `findRange()` and `count()` take an optional argument to enhance the queries, which can specify JPA `queryCriteria`. This takes a form of `builder -> builder.queryCriteria().countQueryCriteria().build()`. There are also `build` and `accept` convenience methods in  `QueryEnhancement` interface that can be passed via a method reference instead of a builder. `ParameterFunction` interface can be used to extract common parameters for both `count()` and `find()` methods, or customize individual methods as required.
+`findAll()`, `findRange()` and `count()` take an optional argument to enhance the queries, which can add additional JPA clauses, enhancements and hints. This parameter takes a form of `QueryEnhancement` interface, which extends `BiConsumer` interface. There are a number of `accept` convenience methods in  `QueryEnhancement` interface that can be passed via a method reference.
 [source,java]
 .Enhanced query and hints example
 ----

--- a/flowlogix-bom/pom.xml
+++ b/flowlogix-bom/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.flowlogix</groupId>
     <artifactId>flowlogix-bom</artifactId>
-    <version>8.x-SNAPSHOT</version>
+    <version>9.x-SNAPSHOT</version>
     <name>FlowLogix Bill of Materials</name>
     <packaging>pom</packaging>
 
@@ -18,7 +18,7 @@
     <parent>
         <groupId>com.flowlogix</groupId>
         <artifactId>flowlogix</artifactId>
-        <version>8.x-SNAPSHOT</version>
+        <version>9.x-SNAPSHOT</version>
     </parent>
 
     <dependencyManagement>

--- a/jakarta-ee/flowlogix-datamodel/pom.xml
+++ b/jakarta-ee/flowlogix-datamodel/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.flowlogix</groupId>
     <artifactId>flowlogix-datamodel</artifactId>
-    <version>8.x-SNAPSHOT</version>
+    <version>9.x-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Flow Logix PrimeFaces Data Model</name>
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.flowlogix</groupId>
         <artifactId>jakarta-ee</artifactId>
-        <version>8.x-SNAPSHOT</version>
+        <version>9.x-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/jakarta-ee/flowlogix-datamodel/src/main/java/com/flowlogix/jeedao/primefaces/internal/JPAModelImpl.java
+++ b/jakarta-ee/flowlogix-datamodel/src/main/java/com/flowlogix/jeedao/primefaces/internal/JPAModelImpl.java
@@ -15,8 +15,8 @@
  */
 package com.flowlogix.jeedao.primefaces.internal;
 
+import com.flowlogix.api.dao.DaoHelper.QueryCriteria;
 import com.flowlogix.jeedao.DaoHelper;
-import com.flowlogix.jeedao.DaoHelper.QueryCriteria;
 import com.flowlogix.jeedao.primefaces.Filter;
 import com.flowlogix.jeedao.primefaces.Filter.FilterData;
 import com.flowlogix.jeedao.primefaces.Filter.FilterColumnData;

--- a/jakarta-ee/flowlogix-datamodel/src/main/java/com/flowlogix/jeedao/primefaces/internal/JPAModelImpl.java
+++ b/jakarta-ee/flowlogix-datamodel/src/main/java/com/flowlogix/jeedao/primefaces/internal/JPAModelImpl.java
@@ -15,7 +15,8 @@
  */
 package com.flowlogix.jeedao.primefaces.internal;
 
-import com.flowlogix.api.dao.DaoHelper.QueryCriteria;
+import com.flowlogix.api.dao.JPAFinder.QueryCriteria;
+import com.flowlogix.api.dao.JPAFinderHelper;
 import com.flowlogix.jeedao.DaoHelper;
 import com.flowlogix.jeedao.primefaces.Filter;
 import com.flowlogix.jeedao.primefaces.Filter.FilterData;
@@ -95,7 +96,7 @@ public class JPAModelImpl<TT> implements Serializable {
      * entity class
      */
     private final @NonNull @Getter Class<TT> entityClass;
-    private final Lazy<DaoHelper<TT>> daoHelper = new Lazy<>(this::createDaoHelper);
+    private final Lazy<JPAFinderHelper<TT>> jpaFinder = new Lazy<>(this::createJPAFinder);
     /**
      * convert String key into key object
      */
@@ -189,20 +190,20 @@ public class JPAModelImpl<TT> implements Serializable {
     public static class JPAModelImplBuilder<TT> { }
 
     public int count(Map<String, FilterMeta> filters) {
-        return toIntExact(daoHelper.get().count(builder -> builder
+        return toIntExact(jpaFinder.get().count(builder -> builder
                 .countQueryCriteria(cqc -> cqc.query().where(getFilters(filters, cqc.builder(), cqc.root())))
                 .build()));
     }
 
     public List<TT> findRows(int first, int pageSize, Map<String, FilterMeta> filters, Map<String, SortMeta> sortMeta) {
         return optimizer.apply(
-                daoHelper.get().findRange(Integer.max(first, 0), Integer.max(first + pageSize, 1),
+                jpaFinder.get().findRange(Integer.max(first, 0), Integer.max(first + pageSize, 1),
                         builder -> builder.queryCriteria(qc -> addToCriteria(qc, filters, sortMeta))
                                 .build())).getResultList();
     }
 
     public Supplier<EntityManager> getEntityManager() {
-        return daoHelper.get().getEntityManager();
+        return jpaFinder.get().getEntityManager();
     }
 
     @SuppressWarnings("unchecked")
@@ -214,7 +215,7 @@ public class JPAModelImpl<TT> implements Serializable {
         return keyConverter != null ? keyConverter : defaultKeyConverter.get();
     }
 
-    private DaoHelper<TT> createDaoHelper() {
+    private JPAFinderHelper<TT> createJPAFinder() {
         if (entityManager != null) {
             return new DaoHelper<>(entityManager, entityClass);
         } else {
@@ -490,7 +491,7 @@ public class JPAModelImpl<TT> implements Serializable {
 
     @SneakyThrows(ReflectiveOperationException.class)
     private Object getPrimaryKey(Optional<TT> entry) {
-        return daoHelper.get().getEntityManager().get().getEntityManagerFactory().getPersistenceUnitUtil()
+        return jpaFinder.get().getEntityManager().get().getEntityManagerFactory().getPersistenceUnitUtil()
                 .getIdentifier(entry.orElse(ConstructorUtils.invokeConstructor(getEntityClass())));
     }
 

--- a/jakarta-ee/flowlogix-datamodel/src/main/java/com/flowlogix/jeedao/primefaces/internal/JPAModelImpl.java
+++ b/jakarta-ee/flowlogix-datamodel/src/main/java/com/flowlogix/jeedao/primefaces/internal/JPAModelImpl.java
@@ -190,16 +190,13 @@ public class JPAModelImpl<TT> implements Serializable {
     public static class JPAModelImplBuilder<TT> { }
 
     public int count(Map<String, FilterMeta> filters) {
-        return toIntExact(jpaFinder.get().count(builder -> builder
-                .countQueryCriteria(cqc -> cqc.query().where(getFilters(filters, cqc.builder(), cqc.root())))
-                .build()));
+        return toIntExact(jpaFinder.get().count(cqc -> cqc.query().where(getFilters(filters, cqc.builder(), cqc.root()))));
     }
 
     public List<TT> findRows(int first, int pageSize, Map<String, FilterMeta> filters, Map<String, SortMeta> sortMeta) {
         return optimizer.apply(
                 jpaFinder.get().findRange(Integer.max(first, 0), Integer.max(first + pageSize, 1),
-                        builder -> builder.queryCriteria(qc -> addToCriteria(qc, filters, sortMeta))
-                                .build())).getResultList();
+                        qc -> addToCriteria(qc, filters, sortMeta))).getResultList();
     }
 
     public Supplier<EntityManager> getEntityManager() {

--- a/jakarta-ee/flowlogix-datamodel/src/main/java/com/flowlogix/jeedao/primefaces/internal/JPAModelImpl.java
+++ b/jakarta-ee/flowlogix-datamodel/src/main/java/com/flowlogix/jeedao/primefaces/internal/JPAModelImpl.java
@@ -316,7 +316,7 @@ public class JPAModelImpl<TT> implements Serializable {
                     convertedValue = valueConverter.getAsObject(Faces.getContext(),
                             UIComponent.getCurrentComponent(Faces.getContext()), value.toString());
                 }
-            } catch (Throwable e) {
+            } catch (Exception e) {
                 log.debug("unable to convert via Faces", e);
             }
         }

--- a/jakarta-ee/flowlogix-jee/pom.xml
+++ b/jakarta-ee/flowlogix-jee/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.flowlogix</groupId>
     <artifactId>flowlogix-jee</artifactId>
-    <version>8.x-SNAPSHOT</version>
+    <version>9.x-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Flow Logix JEE Components</name>
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.flowlogix</groupId>
         <artifactId>jakarta-ee</artifactId>
-        <version>8.x-SNAPSHOT</version>
+        <version>9.x-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/jakarta-ee/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/ExampleDAO.java
+++ b/jakarta-ee/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/ExampleDAO.java
@@ -30,7 +30,7 @@ public class ExampleDAO {
     @PersistenceContext(unitName = "demo-pu")
     EntityManager em;
     @Delegate
-    JPAFinder<UserEntity> helper = new DaoHelper<>(() -> em, UserEntity.class);
+    JPAFinder<UserEntity> jpaFinder = new DaoHelper<>(() -> em, UserEntity.class);
 }
 // end::simpleExampleDAO[] // @replace regex='.*\n' replacement=""
 // @end

--- a/jakarta-ee/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/ExampleDAO.java
+++ b/jakarta-ee/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/ExampleDAO.java
@@ -15,6 +15,7 @@
  */
 package com.flowlogix.demo.jeedao;
 
+import com.flowlogix.api.dao.JPAFinder;
 import com.flowlogix.jeedao.DaoHelper;
 import com.flowlogix.demo.jeedao.entities.UserEntity;
 import jakarta.ejb.Stateless;
@@ -29,7 +30,7 @@ public class ExampleDAO {
     @PersistenceContext(unitName = "demo-pu")
     EntityManager em;
     @Delegate
-    DaoHelper<UserEntity> helper = new DaoHelper<>(() -> em, UserEntity.class);
+    JPAFinder<UserEntity> helper = new DaoHelper<>(() -> em, UserEntity.class);
 }
 // end::simpleExampleDAO[] // @replace regex='.*\n' replacement=""
 // @end

--- a/jakarta-ee/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/ExampleDelegateDAO.java
+++ b/jakarta-ee/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/ExampleDelegateDAO.java
@@ -15,8 +15,8 @@
  */
 package com.flowlogix.demo.jeedao;
 
+import com.flowlogix.api.dao.JPAFinderHelper;
 import com.flowlogix.api.dao.JPAFinderHelper.EntityManagerExclusions;
-import com.flowlogix.jeedao.DaoHelper;
 import com.flowlogix.demo.jeedao.entities.UserEntity;
 import jakarta.ejb.Stateless;
 import jakarta.inject.Inject;
@@ -32,7 +32,7 @@ public class ExampleDelegateDAO {
     EntityManager entityManager;
     @Inject
     @Delegate
-    DaoHelper<UserEntity> helper;
+    JPAFinderHelper<UserEntity> helper;
 }
 // end::delegateDAO[] // @replace regex='.*\n' replacement=""
 // @end

--- a/jakarta-ee/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/ExampleDelegateDAO.java
+++ b/jakarta-ee/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/ExampleDelegateDAO.java
@@ -15,8 +15,8 @@
  */
 package com.flowlogix.demo.jeedao;
 
+import com.flowlogix.api.dao.JPAFinderHelper.EntityManagerExclusions;
 import com.flowlogix.jeedao.DaoHelper;
-import com.flowlogix.jeedao.DaoHelper.EntityManagerExclusions;
 import com.flowlogix.demo.jeedao.entities.UserEntity;
 import jakarta.ejb.Stateless;
 import jakarta.inject.Inject;

--- a/jakarta-ee/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/ExampleDelegateDAO.java
+++ b/jakarta-ee/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/ExampleDelegateDAO.java
@@ -32,7 +32,7 @@ public class ExampleDelegateDAO {
     EntityManager entityManager;
     @Inject
     @Delegate
-    JPAFinderHelper<UserEntity> helper;
+    JPAFinderHelper<UserEntity> jpaFinder;
 }
 // end::delegateDAO[] // @replace regex='.*\n' replacement=""
 // @end

--- a/jakarta-ee/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/InheritedDAO.java
+++ b/jakarta-ee/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/InheritedDAO.java
@@ -32,7 +32,7 @@ public class InheritedDAO extends InheritableDaoHelper<UserEntity> {
 
     @PostConstruct
     void init() {
-        daoHelper = new DaoHelper<>(() -> entityManager, UserEntity.class);
+        jpaFinder = new DaoHelper<>(() -> entityManager, UserEntity.class);
     }
 }
 // end::inheritedDAO[] // @replace regex='.*\n' replacement=""

--- a/jakarta-ee/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/InjectedDAO.java
+++ b/jakarta-ee/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/InjectedDAO.java
@@ -31,7 +31,7 @@ import lombok.experimental.Delegate;
 public class InjectedDAO {
     @Inject
     @Delegate
-    JPAFinder<UserEntity> helper;
+    JPAFinder<UserEntity> jpaFinder;
 }
 // end::injectedExampleDAO[] // @replace regex='.*\n' replacement=""
 // @end

--- a/jakarta-ee/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/InjectedDAO.java
+++ b/jakarta-ee/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/InjectedDAO.java
@@ -15,7 +15,7 @@
  */
 package com.flowlogix.demo.jeedao;
 
-import com.flowlogix.jeedao.DaoHelper;
+import com.flowlogix.api.dao.JPAFinder;
 import com.flowlogix.demo.jeedao.entities.UserEntity;
 import jakarta.ejb.Stateless;
 import jakarta.inject.Inject;
@@ -23,7 +23,7 @@ import jakarta.persistence.EntityManager;
 import lombok.experimental.Delegate;
 
 /**
- * Demonstrates injecting {@link DaoHelper} using default {@link EntityManager}
+ * Demonstrates injecting {@link JPAFinder} using default {@link EntityManager}
  */
 // @start region="injectedExampleDAO"
 // tag::injectedExampleDAO[] // @replace regex='.*\n' replacement=""
@@ -31,7 +31,7 @@ import lombok.experimental.Delegate;
 public class InjectedDAO {
     @Inject
     @Delegate
-    DaoHelper<UserEntity> helper;
+    JPAFinder<UserEntity> helper;
 }
 // end::injectedExampleDAO[] // @replace regex='.*\n' replacement=""
 // @end

--- a/jakarta-ee/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/InjectedNonDefaultDAO.java
+++ b/jakarta-ee/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/InjectedNonDefaultDAO.java
@@ -15,7 +15,7 @@
  */
 package com.flowlogix.demo.jeedao;
 
-import com.flowlogix.jeedao.DaoHelper;
+import com.flowlogix.api.dao.JPAFinder;
 import com.flowlogix.jeedao.EntityManagerSelector;
 import com.flowlogix.demo.jeedao.entities.UserEntity;
 import jakarta.ejb.Stateless;
@@ -24,7 +24,7 @@ import jakarta.persistence.EntityManager;
 import lombok.experimental.Delegate;
 
 /**
- * Demonstrates injecting {@link DaoHelper} using default {@link EntityManager}
+ * Demonstrates injecting {@link JPAFinder} using default {@link EntityManager}
  */
 // @start region="injectedNonDefaultExampleDAO"
 // tag::injectedNonDefaultExampleDAO[] // @replace regex='.*\n' replacement=""
@@ -33,7 +33,7 @@ public class InjectedNonDefaultDAO {
     @Inject
     @Delegate
     @EntityManagerSelector(NonDefault.class)
-    DaoHelper<UserEntity> helper;
+    JPAFinder<UserEntity> helper;
 }
 // end::injectedNonDefaultExampleDAO[] // @replace regex='.*\n' replacement=""
 // @end

--- a/jakarta-ee/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/InjectedNonDefaultDAO.java
+++ b/jakarta-ee/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/InjectedNonDefaultDAO.java
@@ -33,7 +33,7 @@ public class InjectedNonDefaultDAO {
     @Inject
     @Delegate
     @EntityManagerSelector(NonDefault.class)
-    JPAFinder<UserEntity> helper;
+    JPAFinder<UserEntity> jpaFinder;
 }
 // end::injectedNonDefaultExampleDAO[] // @replace regex='.*\n' replacement=""
 // @end

--- a/jakarta-ee/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/UserDAO.java
+++ b/jakarta-ee/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/UserDAO.java
@@ -43,7 +43,8 @@ public class UserDAO {
                 .where(partial.builder().equal(partial.root()
                         .get(UserEntity_.fullName), userName));
 
-        return new CountAndList(jpaFinder.count(enhancement::accept), jpaFinder.findAll(enhancement::accept)
+        return new CountAndList(jpaFinder.count(enhancement::accept),
+                jpaFinder.findAll(enhancement::accept)
                 .setHint(QueryHints.BATCH_TYPE, BatchFetchType.IN)
                 .getResultList());
     }

--- a/jakarta-ee/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/UserDAO.java
+++ b/jakarta-ee/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/UserDAO.java
@@ -16,8 +16,8 @@
 package com.flowlogix.demo.jeedao;
 
 import com.flowlogix.jeedao.DaoHelper;
-import com.flowlogix.jeedao.DaoHelper.ParameterFunction;
-import com.flowlogix.jeedao.DaoHelper.QueryEnhancement;
+import com.flowlogix.api.dao.DaoHelper.ParameterFunction;
+import com.flowlogix.api.dao.DaoHelper.QueryEnhancement;
 import com.flowlogix.demo.jeedao.entities.UserEntity;
 import com.flowlogix.demo.jeedao.entities.UserEntity_;
 import jakarta.ejb.Stateless;

--- a/jakarta-ee/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/UserDAO.java
+++ b/jakarta-ee/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/UserDAO.java
@@ -15,7 +15,7 @@
  */
 package com.flowlogix.demo.jeedao;
 
-import com.flowlogix.jeedao.DaoHelper;
+import com.flowlogix.api.dao.JPAFinderNative;
 import com.flowlogix.api.dao.JPAFinder.ParameterFunction;
 import com.flowlogix.api.dao.JPAFinder.QueryEnhancement;
 import com.flowlogix.demo.jeedao.entities.UserEntity;
@@ -34,7 +34,7 @@ import java.util.List;
 public class UserDAO {
     @Inject
     @Delegate
-    DaoHelper<UserEntity> daoHelper;
+    JPAFinderNative<UserEntity> daoHelper;
     // @start region="daoParameters"
     // tag::daoParameters[] // @replace regex='.*\n' replacement=""
     public record CountAndList(long count, List<UserEntity> list) { };

--- a/jakarta-ee/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/UserDAO.java
+++ b/jakarta-ee/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/UserDAO.java
@@ -15,7 +15,7 @@
  */
 package com.flowlogix.demo.jeedao;
 
-import com.flowlogix.api.dao.JPAFinderNative;
+import com.flowlogix.api.dao.JPANativeQuery;
 import com.flowlogix.api.dao.JPAFinder.QueryEnhancement;
 import com.flowlogix.demo.jeedao.entities.UserEntity;
 import com.flowlogix.demo.jeedao.entities.UserEntity_;
@@ -33,7 +33,7 @@ import java.util.List;
 public class UserDAO {
     @Inject
     @Delegate
-    JPAFinderNative<UserEntity> jpaFinder;
+    JPANativeQuery<UserEntity> jpaFinder;
     // @start region="daoParameters"
     // tag::daoParameters[] // @replace regex='.*\n' replacement=""
     public record CountAndList(long count, List<UserEntity> list) { };

--- a/jakarta-ee/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/UserDAO.java
+++ b/jakarta-ee/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/UserDAO.java
@@ -16,8 +16,8 @@
 package com.flowlogix.demo.jeedao;
 
 import com.flowlogix.jeedao.DaoHelper;
-import com.flowlogix.api.dao.DaoHelper.ParameterFunction;
-import com.flowlogix.api.dao.DaoHelper.QueryEnhancement;
+import com.flowlogix.api.dao.JPAFinder.ParameterFunction;
+import com.flowlogix.api.dao.JPAFinder.QueryEnhancement;
 import com.flowlogix.demo.jeedao.entities.UserEntity;
 import com.flowlogix.demo.jeedao.entities.UserEntity_;
 import jakarta.ejb.Stateless;

--- a/jakarta-ee/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/UserDAO.java
+++ b/jakarta-ee/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/UserDAO.java
@@ -16,7 +16,6 @@
 package com.flowlogix.demo.jeedao;
 
 import com.flowlogix.api.dao.JPAFinderNative;
-import com.flowlogix.api.dao.JPAFinder.ParameterFunction;
 import com.flowlogix.api.dao.JPAFinder.QueryEnhancement;
 import com.flowlogix.demo.jeedao.entities.UserEntity;
 import com.flowlogix.demo.jeedao.entities.UserEntity_;
@@ -34,7 +33,7 @@ import java.util.List;
 public class UserDAO {
     @Inject
     @Delegate
-    JPAFinderNative<UserEntity> daoHelper;
+    JPAFinderNative<UserEntity> jpaFinder;
     // @start region="daoParameters"
     // tag::daoParameters[] // @replace regex='.*\n' replacement=""
     public record CountAndList(long count, List<UserEntity> list) { };
@@ -44,7 +43,7 @@ public class UserDAO {
                 .where(partial.builder().equal(partial.root()
                         .get(UserEntity_.fullName), userName));
 
-        return new CountAndList(daoHelper.count(enhancement::build), daoHelper.findAll(enhancement::build)
+        return new CountAndList(jpaFinder.count(enhancement::accept), jpaFinder.findAll(enhancement::accept)
                 .setHint(QueryHints.BATCH_TYPE, BatchFetchType.IN)
                 .getResultList());
     }
@@ -62,12 +61,8 @@ public class UserDAO {
         QueryEnhancement<UserEntity> orderBy = (partial, criteria) -> criteria
                 .orderBy(partial.builder().desc(partial.root().get(UserEntity_.fullName)));
 
-        ParameterFunction<UserEntity> params = builder -> builder
-                .countQueryCriteria(enhancement::accept)
-                .queryCriteria(enhancement.andThen(orderBy)::accept)
-                .build();
-
-        return new CountAndList(daoHelper.count(params), daoHelper.findAll(params)
+        return new CountAndList(jpaFinder.count(enhancement::accept),
+                jpaFinder.findAll(enhancement.andThen(orderBy)::accept)
                 .getResultList());
     }
     // end::daoExtractedParameters[] // @replace regex='.*\n' replacement=""
@@ -76,7 +71,7 @@ public class UserDAO {
     // @start region="nativeQuery"
     // tag::nativeQuery[] // @replace regex='.*\n' replacement=""
     public List<UserEntity> findByNative(String sql) {
-        return daoHelper.createNativeQuery(sql, daoHelper.getEntityClass()).getResultList();
+        return jpaFinder.createNativeQuery(sql, jpaFinder.getEntityClass()).getResultList();
     }
     // end::nativeQuery[] // @replace regex='.*\n' replacement=""
     // @end

--- a/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/api/dao/DaoHelper.java
+++ b/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/api/dao/DaoHelper.java
@@ -111,13 +111,13 @@ public interface DaoHelper<TT> {
          * @param builder
          * @return
          */
-        default com.flowlogix.jeedao.DaoHelper.Parameters<TT> build(ParametersBuilder<TT> builder) {
+        default Parameters<TT> build(ParametersBuilder<TT> builder) {
             return builder.queryCriteria(this::accept).countQueryCriteria(this::accept)
                     .build();
         }
 
         /**
-         * Convenience method for using {@link com.flowlogix.jeedao.DaoHelper.Parameters#queryCriteria} parameters
+         * Convenience method for using {@link Parameters#queryCriteria} parameters
          * @param criteria
          */
         default void accept(QueryCriteria<TT> criteria) {
@@ -125,7 +125,7 @@ public interface DaoHelper<TT> {
         }
 
         /**
-         * Convenience method for using {@link com.flowlogix.jeedao.DaoHelper.Parameters#countQueryCriteria} parameters
+         * Convenience method for using {@link Parameters#countQueryCriteria} parameters
          * @param criteria
          */
         default void accept(CountQueryCriteria<TT> criteria) {
@@ -151,7 +151,7 @@ public interface DaoHelper<TT> {
      * {@snippet class = "com.flowlogix.demo.jeedao.UserDAO" region = "daoParameters"}
      */
     @FunctionalInterface
-    interface ParameterFunction<TT> extends Function<ParametersBuilder<TT>, com.flowlogix.jeedao.DaoHelper.Parameters<TT>> { }
+    interface ParameterFunction<TT> extends Function<ParametersBuilder<TT>, Parameters<TT>> { }
 
     /**
      * Parameters for enriching

--- a/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/api/dao/DaoHelper.java
+++ b/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/api/dao/DaoHelper.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (C) 2011-2024 Flow Logix, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.flowlogix.api.dao;
+
+import com.flowlogix.api.dao.DaoHelper.Parameters.ParametersBuilder;
+import com.flowlogix.jeedao.InheritableDaoHelper;
+import jakarta.persistence.TypedQuery;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * Main value-add is ability to easily query enhancement criteria to
+ * {@link #findAll()} and {@link #findRange(long, long)} methods,
+ * as well as {@link #count()} methods
+ * <p>
+ * Another differentiator is that this class doesn't require inheritance,
+ * although some use cases could inherit from {@link InheritableDaoHelper} class.
+ * <p>
+ * <em>Simple Example:</em>
+ * {@snippet class="com.flowlogix.demo.jeedao.ExampleDAO" region="simpleExampleDAO"}
+ * <p>
+ * <em>Injected Example:</em>
+ * {@snippet class="com.flowlogix.demo.jeedao.InjectedDAO" region="injectedExampleDAO"}
+ * <p>
+ * <em>Injected Example with non-default EntityManager:</em>
+ * {@snippet class="com.flowlogix.demo.jeedao.InjectedNonDefaultDAO" region="injectedNonDefaultExampleDAO"}
+ *
+ * @param <TT> Entity Type
+ *
+ * @author lprimak
+ */
+public interface DaoHelper<TT> {
+    /**
+     * QueryCriteria record contains {@link CriteriaBuilder}, {@link Root} and {@link CriteriaQuery}
+     * @param <TT> Entity Type of Criteria
+     * @param builder
+     * @param root
+     * @param query
+     */
+    record QueryCriteria<TT>(CriteriaBuilder builder, Root<TT> root, CriteriaQuery<TT> query) {
+        /**
+         * @return partial query criteria, without the JPA {@link CriteriaQuery} object
+         */
+        public PartialQueryCriteria<TT> partial() {
+            return new PartialQueryCriteria<>(builder, root);
+        }
+    }
+
+    /**
+     * Specialized <b>Count</b>QueryCriteria record contains
+     * {@link CriteriaBuilder}, {@link Root} and {@link CriteriaQuery}{@code <Long>}
+     * @param <TT> Entity Type of Criteria
+     * @param builder
+     * @param root
+     * @param query
+     */
+    record CountQueryCriteria<TT>(CriteriaBuilder builder, Root<TT> root, CriteriaQuery<Long> query) {
+        /**
+         * @return partial query criteria, without the JPA {@link CriteriaQuery} object
+         */
+        public PartialQueryCriteria<TT> partial() {
+            return new PartialQueryCriteria<>(builder, root);
+        }
+    }
+
+    /**
+     * Partial query criteria, only {@link CriteriaBuilder} and {@link Root}
+     * Used for common enhancing query methods / lambdas
+     * <p>
+     * {@snippet class = "com.flowlogix.demo.jeedao.UserDAO" region = "daoParameters"}
+     *
+     * @param builder
+     * @param root
+     * @param <TT>
+     */
+    record PartialQueryCriteria<TT>(CriteriaBuilder builder, Root<TT> root) { }
+
+    /**
+     * Convenience interface for use with {@link PartialQueryCriteria}
+     * <p>
+     * {@snippet class = "com.flowlogix.demo.jeedao.UserDAO" region = "daoParameters"}
+
+     * @param <TT> Entity Type
+     */
+    interface QueryEnhancement<TT> extends BiConsumer<PartialQueryCriteria<TT>, CriteriaQuery<?>> {
+        /**
+         * Convenience method for creating parameters to
+         * {@link #count(Function)} and {@link #findAll(Function)} methods and friends.
+         * Useful when the same enhanced queries are used for both count() and find() methods.
+         *
+         * @param builder
+         * @return
+         */
+        default com.flowlogix.jeedao.DaoHelper.Parameters<TT> build(ParametersBuilder<TT> builder) {
+            return builder.queryCriteria(this::accept).countQueryCriteria(this::accept)
+                    .build();
+        }
+
+        /**
+         * Convenience method for using {@link com.flowlogix.jeedao.DaoHelper.Parameters#queryCriteria} parameters
+         * @param criteria
+         */
+        default void accept(QueryCriteria<TT> criteria) {
+            accept(criteria.partial(), criteria.query());
+        }
+
+        /**
+         * Convenience method for using {@link com.flowlogix.jeedao.DaoHelper.Parameters#countQueryCriteria} parameters
+         * @param criteria
+         */
+        default void accept(CountQueryCriteria<TT> criteria) {
+            accept(criteria.partial(), criteria.query());
+        }
+
+        /**
+         * Allows for combinations of enhancements via method references
+         * @see BiConsumer#andThen(BiConsumer)
+         *
+         * @param after
+         * @return combination lambda
+         */
+        default QueryEnhancement<TT> andThen(QueryEnhancement<TT> after) {
+            return (l, r) -> BiConsumer.super.andThen(after).accept(l, r);
+        }
+    }
+
+    /**
+     * Convenience interface to extract parameter builder into a lambda
+     * @param <TT> Entity Type
+     * <p>
+     * {@snippet class = "com.flowlogix.demo.jeedao.UserDAO" region = "daoParameters"}
+     */
+    @FunctionalInterface
+    interface ParameterFunction<TT> extends Function<ParametersBuilder<TT>, com.flowlogix.jeedao.DaoHelper.Parameters<TT>> { }
+
+    /**
+     * Parameters for enriching
+     * {@link #count(Function)}, {@link #findAll(Function)} and {@link #findRange(long, long, Function)}
+     * methods with additional criteria
+     * <p>
+     * {@snippet class = "com.flowlogix.demo.jeedao.UserDAO" region = "daoParameters"}
+     *
+     * @param <TT> Entity Type
+     */
+    @Builder
+    @Getter
+    class Parameters<TT> {
+        /**
+         * query criteria enhancement
+         */
+        @Builder.Default
+        @NonNull
+        private final Consumer<QueryCriteria<TT>> queryCriteria = c -> { };
+        /**
+         * query criteria enhancement for count operation here
+         */
+        @Builder.Default
+        @NonNull
+        private final Consumer<CountQueryCriteria<TT>> countQueryCriteria = c -> { };
+
+        /**
+         * @hidden
+         * just for javadoc
+         * @param <TT>
+         */
+        public static class ParametersBuilder<TT> { }
+    }
+
+    TypedQuery<TT> findAll();
+    <FF extends Function<ParametersBuilder<TT>, Parameters<TT>>> TypedQuery<TT> findAll(FF paramsBuilder);
+    TypedQuery<TT> findRange(long min, long max);
+    <FF extends Function<ParametersBuilder<TT>, Parameters<TT>>> TypedQuery<TT> findRange(long min, long max, FF paramsBuilder);
+
+    long count();
+    <FF extends Function<ParametersBuilder<TT>, Parameters<TT>>> long count(FF paramsBuilder);
+    QueryCriteria<TT> buildQueryCriteria();
+    <RR> QueryCriteria<RR> buildQueryCriteria(Class<RR> cls);
+
+}

--- a/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/api/dao/JPAFinder.java
+++ b/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/api/dao/JPAFinder.java
@@ -15,18 +15,13 @@
  */
 package com.flowlogix.api.dao;
 
-import com.flowlogix.api.dao.JPAFinder.Parameters.ParametersBuilder;
 import com.flowlogix.jeedao.InheritableDaoHelper;
 import jakarta.persistence.TypedQuery;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Root;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NonNull;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 /**
  * Main value-add is ability to easily query enhancement criteria to
@@ -50,6 +45,14 @@ import java.util.function.Function;
  * @author lprimak
  */
 public interface JPAFinder<TT> {
+    TypedQuery<TT> findAll();
+    TypedQuery<TT> findAll(Consumer<QueryCriteria<TT>> queryCriteria);
+    TypedQuery<TT> findRange(long min, long max);
+    TypedQuery<TT> findRange(long min, long max, Consumer<QueryCriteria<TT>> queryCriteria);
+
+    long count();
+    long count(Consumer<CountQueryCriteria<TT>> countQueryCriteria);
+
     /**
      * QueryCriteria record contains {@link CriteriaBuilder}, {@link Root} and {@link CriteriaQuery}
      * @param <TT> Entity Type of Criteria
@@ -104,19 +107,6 @@ public interface JPAFinder<TT> {
      */
     interface QueryEnhancement<TT> extends BiConsumer<PartialQueryCriteria<TT>, CriteriaQuery<?>> {
         /**
-         * Convenience method for creating parameters to
-         * {@link #count(Function)} and {@link #findAll(Function)} methods and friends.
-         * Useful when the same enhanced queries are used for both count() and find() methods.
-         *
-         * @param builder
-         * @return
-         */
-        default Parameters<TT> build(ParametersBuilder<TT> builder) {
-            return builder.queryCriteria(this::accept).countQueryCriteria(this::accept)
-                    .build();
-        }
-
-        /**
          * Convenience method for using {@link Parameters#queryCriteria} parameters
          * @param criteria
          */
@@ -144,55 +134,6 @@ public interface JPAFinder<TT> {
         }
     }
 
-    /**
-     * Convenience interface to extract parameter builder into a lambda
-     * @param <TT> Entity Type
-     * <p>
-     * {@snippet class = "com.flowlogix.demo.jeedao.UserDAO" region = "daoParameters"}
-     */
-    @FunctionalInterface
-    interface ParameterFunction<TT> extends Function<ParametersBuilder<TT>, Parameters<TT>> { }
-
-    /**
-     * Parameters for enriching
-     * {@link #count(Function)}, {@link #findAll(Function)} and {@link #findRange(long, long, Function)}
-     * methods with additional criteria
-     * <p>
-     * {@snippet class = "com.flowlogix.demo.jeedao.UserDAO" region = "daoParameters"}
-     *
-     * @param <TT> Entity Type
-     */
-    @Builder
-    @Getter
-    class Parameters<TT> {
-        /**
-         * query criteria enhancement
-         */
-        @Builder.Default
-        @NonNull
-        private final Consumer<QueryCriteria<TT>> queryCriteria = c -> { };
-        /**
-         * query criteria enhancement for count operation here
-         */
-        @Builder.Default
-        @NonNull
-        private final Consumer<CountQueryCriteria<TT>> countQueryCriteria = c -> { };
-
-        /**
-         * @hidden
-         * just for javadoc
-         * @param <TT>
-         */
-        public static class ParametersBuilder<TT> { }
-    }
-
-    TypedQuery<TT> findAll();
-    <FF extends Function<ParametersBuilder<TT>, Parameters<TT>>> TypedQuery<TT> findAll(FF paramsBuilder);
-    TypedQuery<TT> findRange(long min, long max);
-    <FF extends Function<ParametersBuilder<TT>, Parameters<TT>>> TypedQuery<TT> findRange(long min, long max, FF paramsBuilder);
-
-    long count();
-    <FF extends Function<ParametersBuilder<TT>, Parameters<TT>>> long count(FF paramsBuilder);
     QueryCriteria<TT> buildQueryCriteria();
     <RR> QueryCriteria<RR> buildQueryCriteria(Class<RR> cls);
 }

--- a/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/api/dao/JPAFinder.java
+++ b/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/api/dao/JPAFinder.java
@@ -15,7 +15,7 @@
  */
 package com.flowlogix.api.dao;
 
-import com.flowlogix.api.dao.DaoHelper.Parameters.ParametersBuilder;
+import com.flowlogix.api.dao.JPAFinder.Parameters.ParametersBuilder;
 import com.flowlogix.jeedao.InheritableDaoHelper;
 import jakarta.persistence.TypedQuery;
 import jakarta.persistence.criteria.CriteriaBuilder;
@@ -49,7 +49,7 @@ import java.util.function.Function;
  *
  * @author lprimak
  */
-public interface DaoHelper<TT> {
+public interface JPAFinder<TT> {
     /**
      * QueryCriteria record contains {@link CriteriaBuilder}, {@link Root} and {@link CriteriaQuery}
      * @param <TT> Entity Type of Criteria
@@ -195,5 +195,4 @@ public interface DaoHelper<TT> {
     <FF extends Function<ParametersBuilder<TT>, Parameters<TT>>> long count(FF paramsBuilder);
     QueryCriteria<TT> buildQueryCriteria();
     <RR> QueryCriteria<RR> buildQueryCriteria(Class<RR> cls);
-
 }

--- a/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/api/dao/JPAFinder.java
+++ b/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/api/dao/JPAFinder.java
@@ -133,7 +133,4 @@ public interface JPAFinder<TT> {
             return (l, r) -> BiConsumer.super.andThen(after).accept(l, r);
         }
     }
-
-    QueryCriteria<TT> buildQueryCriteria();
-    <RR> QueryCriteria<RR> buildQueryCriteria(Class<RR> cls);
 }

--- a/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/api/dao/JPAFinder.java
+++ b/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/api/dao/JPAFinder.java
@@ -24,7 +24,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 /**
- * Main value-add is ability to easily query enhancement criteria to
+ * Easily add query enhancement criteria to
  * {@link #findAll()} and {@link #findRange(long, long)} methods,
  * as well as {@link #count()} methods
  * <p>
@@ -45,12 +45,58 @@ import java.util.function.Consumer;
  * @author lprimak
  */
 public interface JPAFinder<TT> {
+    /**
+     * finds all entities
+     *
+     * @return query
+     */
     TypedQuery<TT> findAll();
+
+    /**
+     * find all entities with enriched criteria
+     * <p>
+     * Example:
+     * <p>
+     * {@code findAll(enhancement::accept)}
+     * <p>
+     * {@snippet class = "com.flowlogix.demo.jeedao.UserDAO" region = "daoParameters"}
+     *
+     * @param queryCriteria
+     * @return query
+     */
     TypedQuery<TT> findAll(Consumer<QueryCriteria<TT>> queryCriteria);
+
+    /**
+     * find entities given a specified range
+     *
+     * @param min minimum index, starting with zero
+     * @param max maximum index
+     * @return query
+     */
     TypedQuery<TT> findRange(long min, long max);
+
+    /**
+     * find entities with enriched criteria given a specified range
+     *
+     * @param min minimum index, starting with zero
+     * @param max maximum index
+     * @param queryCriteria
+     * @return query
+     */
     TypedQuery<TT> findRange(long min, long max, Consumer<QueryCriteria<TT>> queryCriteria);
 
+    /**
+     * count rows
+     * @return row count
+     */
     long count();
+
+    /**
+     * count with enriched criteria
+     *
+     * @param countQueryCriteria
+     * @return row count
+     */
     long count(Consumer<CountQueryCriteria<TT>> countQueryCriteria);
 
     /**
@@ -88,7 +134,7 @@ public interface JPAFinder<TT> {
 
     /**
      * Partial query criteria, only {@link CriteriaBuilder} and {@link Root}
-     * Used for common enhancing query methods / lambdas
+     * Used for common enriched query methods / lambdas
      * <p>
      * {@snippet class = "com.flowlogix.demo.jeedao.UserDAO" region = "daoParameters"}
      *
@@ -99,7 +145,7 @@ public interface JPAFinder<TT> {
     record PartialQueryCriteria<TT>(CriteriaBuilder builder, Root<TT> root) { }
 
     /**
-     * Convenience interface for use with {@link PartialQueryCriteria}
+     * Convenience interface for use with {@link PartialQueryCriteria} and {@link QueryCriteria}
      * <p>
      * {@snippet class = "com.flowlogix.demo.jeedao.UserDAO" region = "daoParameters"}
 
@@ -107,7 +153,9 @@ public interface JPAFinder<TT> {
      */
     interface QueryEnhancement<TT> extends BiConsumer<PartialQueryCriteria<TT>, CriteriaQuery<?>> {
         /**
-         * Convenience method for using {@link Parameters#queryCriteria} parameters
+         * Convenience method reference for use in {@link JPAFinder#findAll(Consumer)}
+         * and {@link JPAFinder#findRange(long, long, Consumer)} parameters
+         *
          * @param criteria
          */
         default void accept(QueryCriteria<TT> criteria) {
@@ -115,7 +163,7 @@ public interface JPAFinder<TT> {
         }
 
         /**
-         * Convenience method for using {@link Parameters#countQueryCriteria} parameters
+         * Convenience method reference for use in {@link JPAFinder#count(Consumer)} parameters
          * @param criteria
          */
         default void accept(CountQueryCriteria<TT> criteria) {

--- a/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/api/dao/JPAFinderHelper.java
+++ b/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/api/dao/JPAFinderHelper.java
@@ -20,4 +20,5 @@ import java.util.function.Supplier;
 
 public interface JPAFinderHelper<TT> extends JPAFinder<TT> {
     Supplier<EntityManager> getEntityManager();
+    Class<TT> getEntityClass();
 }

--- a/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/api/dao/JPAFinderHelper.java
+++ b/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/api/dao/JPAFinderHelper.java
@@ -21,4 +21,7 @@ import java.util.function.Supplier;
 public interface JPAFinderHelper<TT> extends JPAFinder<TT> {
     Supplier<EntityManager> getEntityManager();
     Class<TT> getEntityClass();
+
+    QueryCriteria<TT> buildQueryCriteria();
+    <RR> QueryCriteria<RR> buildQueryCriteria(Class<RR> cls);
 }

--- a/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/api/dao/JPAFinderHelper.java
+++ b/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/api/dao/JPAFinderHelper.java
@@ -17,13 +17,49 @@ package com.flowlogix.api.dao;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
 import java.util.function.Supplier;
 
+/**
+ * Enhanced JPA Finder interface that provides access to the entity manager,
+ * the entity class, and the ability to build a {@link QueryCriteria} record
+ * <p>
+ * Also contains convenience interface for use with {@link lombok.experimental.Delegate}
+ *
+ * @param <TT> entity type
+ */
 public interface JPAFinderHelper<TT> extends JPAFinder<TT> {
+    /**
+     * Entity Manager cannot be saved because it's not thread-safe
+     * However, supplier can be returned
+     *
+     * @return {@link Supplier} of {@link EntityManager}
+     */
     Supplier<EntityManager> getEntityManager();
+
+    /**
+     * Returns the entity class
+     * @return entity class
+     */
     Class<TT> getEntityClass();
 
+    /**
+     * Convenience method for building {@link QueryCriteria} record, which contains
+     * {@link CriteriaBuilder}, {@link Root} and {@link CriteriaQuery}
+     *
+     * @return QueryCriteria of Entity Type
+     */
     QueryCriteria<TT> buildQueryCriteria();
+
+    /**
+     * Convenience method for building {@link QueryCriteria} record of any type,
+     * which contains {@link CriteriaBuilder}, {@link Root} and {@link CriteriaQuery}
+     *
+     * @param  cls Type of Query Criteria
+     * @return QueryCriteria of the same Entity Type as the parameter
+     */
     <RR> QueryCriteria<RR> buildQueryCriteria(Class<RR> cls);
 
     /**

--- a/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/api/dao/JPAFinderHelper.java
+++ b/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/api/dao/JPAFinderHelper.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2011-2024 Flow Logix, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.flowlogix.api.dao;
+
+import jakarta.persistence.EntityManager;
+import java.util.function.Supplier;
+
+public interface JPAFinderHelper<TT> extends JPAFinder<TT> {
+    Supplier<EntityManager> getEntityManager();
+}

--- a/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/api/dao/JPAFinderHelper.java
+++ b/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/api/dao/JPAFinderHelper.java
@@ -16,6 +16,7 @@
 package com.flowlogix.api.dao;
 
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
 import java.util.function.Supplier;
 
 public interface JPAFinderHelper<TT> extends JPAFinder<TT> {
@@ -24,4 +25,15 @@ public interface JPAFinderHelper<TT> extends JPAFinder<TT> {
 
     QueryCriteria<TT> buildQueryCriteria();
     <RR> QueryCriteria<RR> buildQueryCriteria(Class<RR> cls);
+
+    /**
+     * Convenience interface for use with {@link lombok.experimental.Delegate} when forwarding methods
+     * of {@link EntityManager} so DaoHelper's own methods get exposed correctly
+     * <p>
+     * {@snippet class = "com.flowlogix.demo.jeedao.ExampleDelegateDAO" region = "delegateDAO"}
+     */
+     interface EntityManagerExclusions {
+        Query createNativeQuery(String sql, Class<?> resultClass);
+        Query createNativeQuery(String sql, String resultMapping);
+    }
 }

--- a/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/api/dao/JPAFinderNative.java
+++ b/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/api/dao/JPAFinderNative.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2011-2024 Flow Logix, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.flowlogix.api.dao;
+
+import com.flowlogix.jeedao.TypedNativeQuery;
+
+public interface JPAFinderNative<TT> extends JPAFinderHelper<TT> {
+    TypedNativeQuery createNativeQuery(String sql, Class<?> resultClass);
+    TypedNativeQuery createNativeQuery(String sql, String resultMapping);
+}

--- a/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/api/dao/JPANativeQuery.java
+++ b/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/api/dao/JPANativeQuery.java
@@ -17,7 +17,7 @@ package com.flowlogix.api.dao;
 
 import com.flowlogix.jeedao.TypedNativeQuery;
 
-public interface JPAFinderNative<TT> extends JPAFinderHelper<TT> {
+public interface JPANativeQuery<TT> extends JPAFinderHelper<TT> {
     TypedNativeQuery createNativeQuery(String sql, Class<?> resultClass);
     TypedNativeQuery createNativeQuery(String sql, String resultMapping);
 }

--- a/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/api/dao/JPANativeQuery.java
+++ b/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/api/dao/JPANativeQuery.java
@@ -16,8 +16,33 @@
 package com.flowlogix.api.dao;
 
 import com.flowlogix.jeedao.TypedNativeQuery;
+import jakarta.persistence.EntityManager;
 
+/**
+ * Interface for creating type-safe JPA native queries
+ *
+ * @param <TT> entity type
+ */
 public interface JPANativeQuery<TT> extends JPAFinderHelper<TT> {
+    /**
+     * Creates a type-safe JPA native query
+     * <p>
+     * {@snippet class = "com.flowlogix.demo.jeedao.UserDAO" region = "nativeQuery"}
+     *
+     * @param sql
+     * @param resultClass {@link EntityManager#createNativeQuery(String, Class)}
+     * @return {@link TypedNativeQuery}
+     */
+
     TypedNativeQuery createNativeQuery(String sql, Class<?> resultClass);
+    /**
+     * Creates a type-safe JPA native query
+     * <p>
+     * {@snippet class = "com.flowlogix.demo.jeedao.UserDAO" region = "nativeQuery"}
+     *
+     * @param sql
+     * @param resultMapping {@link EntityManager#createNativeQuery(String, String)}
+     * @return {@link TypedNativeQuery}
+     */
     TypedNativeQuery createNativeQuery(String sql, String resultMapping);
 }

--- a/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/api/dao/package-info.java
+++ b/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/api/dao/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2011-2024 Flow Logix, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * This package contains the main API classes for the Flow Logix JPA DAO framework
+ */
+package com.flowlogix.api.dao;

--- a/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/jeedao/DaoHelper.java
+++ b/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/jeedao/DaoHelper.java
@@ -30,7 +30,6 @@ import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Root;
 import lombok.Builder;
-import lombok.Getter;
 import lombok.NonNull;
 import org.omnifaces.util.Beans;
 import org.omnifaces.util.Lazy.SerializableSupplier;
@@ -53,7 +52,7 @@ public final class DaoHelper<TT> implements JPANativeQuery<TT>, Serializable {
     /**
      * entity class
      */
-    private final @NonNull @Getter(onMethod = @__(@Override)) Class<TT> entityClass;
+    private final @NonNull Class<TT> entityClass;
 
     @Builder
     public DaoHelper(@NonNull SerializableSupplier<EntityManager> entityManager, @NonNull Class<TT> entityClass) {
@@ -132,13 +131,19 @@ public final class DaoHelper<TT> implements JPANativeQuery<TT>, Serializable {
     }
 
     /**
-     * Entity Manager cannot be saved because it's not thread-safe
-     *
-     * @return {@link Supplier} of {@link EntityManager}
+     * {@inheritDoc}
      */
     @Override
     public Supplier<EntityManager> getEntityManager() {
         return entityManager;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Class<TT> getEntityClass() {
+        return entityClass;
     }
 
     /**
@@ -151,10 +156,7 @@ public final class DaoHelper<TT> implements JPANativeQuery<TT>, Serializable {
     }
 
     /**
-     * Convenience method for building {@link QueryCriteria} record, which contains
-     * {@link CriteriaBuilder}, {@link Root} and {@link CriteriaQuery}
-     *
-     * @return QueryCriteria of Entity Type
+     * {@inheritDoc}
      */
     @Override
     public QueryCriteria<TT> buildQueryCriteria() {
@@ -162,11 +164,7 @@ public final class DaoHelper<TT> implements JPANativeQuery<TT>, Serializable {
     }
 
     /**
-     * Convenience method for building {@link QueryCriteria} record, which contains
-     * {@link CriteriaBuilder}, {@link Root} and {@link CriteriaQuery}
-     *
-     * @param  cls Type of Query Criteria
-     * @return QueryCriteria of the same Entity Type as the parameter
+     * {@inheritDoc}
      */
     @Override
     public <RR> QueryCriteria<RR> buildQueryCriteria(Class<RR> cls) {

--- a/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/jeedao/DaoHelper.java
+++ b/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/jeedao/DaoHelper.java
@@ -66,7 +66,7 @@ public final class DaoHelper<TT> implements JPAFinderNative<TT>, Serializable {
     /**
      * entity class
      */
-    private final @NonNull @Getter Class<TT> entityClass;
+    private final @NonNull @Getter(onMethod = @__(@Override)) Class<TT> entityClass;
 
     @Builder
     public DaoHelper(@NonNull SerializableSupplier<EntityManager> entityManager, @NonNull Class<TT> entityClass) {

--- a/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/jeedao/DaoHelper.java
+++ b/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/jeedao/DaoHelper.java
@@ -176,13 +176,7 @@ public final class DaoHelper<TT> implements JPANativeQuery<TT>, Serializable {
     }
 
     /**
-     * Creates a type-safe JPA native query
-     * <p>
-     * {@snippet class = "com.flowlogix.demo.jeedao.UserDAO" region = "nativeQuery"}
-     *
-     * @param sql
-     * @param resultClass {@link EntityManager#createNativeQuery(String, Class)}
-     * @return {@link TypedNativeQuery}
+     * {@inheritDoc}
      */
     @Override
     public TypedNativeQuery createNativeQuery(String sql, Class<?> resultClass) {
@@ -191,13 +185,7 @@ public final class DaoHelper<TT> implements JPANativeQuery<TT>, Serializable {
     }
 
     /**
-     * Creates a type-safe JPA native query
-     * <p>
-     * {@snippet class = "com.flowlogix.demo.jeedao.UserDAO" region = "nativeQuery"}
-     *
-     * @param sql
-     * @param resultMapping {@link EntityManager#createNativeQuery(String, String)}
-     * @return {@link TypedNativeQuery}
+     * {@inheritDoc}
      */
     @Override
     public TypedNativeQuery createNativeQuery(String sql, String resultMapping) {

--- a/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/jeedao/DaoHelper.java
+++ b/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/jeedao/DaoHelper.java
@@ -21,7 +21,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import com.flowlogix.api.dao.DaoHelper.Parameters.ParametersBuilder;
+import com.flowlogix.api.dao.JPAFinder;
+import com.flowlogix.api.dao.JPAFinder.Parameters.ParametersBuilder;
+import com.flowlogix.api.dao.JPAFinderNative;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
 import jakarta.persistence.TypedQuery;
@@ -39,11 +41,11 @@ import static java.lang.Math.toIntExact;
 /**
  * Lightweight wrapper around common JPA methods
  * This is the primary class in the {@link com.flowlogix.jeedao} package
- * Implementation of {@link com.flowlogix.api.dao.DaoHelper} interface
+ * Implementation of {@link JPAFinder} interface
  *
  * @param <TT>
  */
-public final class DaoHelper<TT> implements com.flowlogix.api.dao.DaoHelper<TT>, Serializable {
+public final class DaoHelper<TT> implements JPAFinderNative<TT>, Serializable {
     private static final long serialVersionUID = 5L;
 
     /**
@@ -151,6 +153,7 @@ public final class DaoHelper<TT> implements com.flowlogix.api.dao.DaoHelper<TT>,
      *
      * @return {@link Supplier} of {@link EntityManager}
      */
+    @Override
     public Supplier<EntityManager> getEntityManager() {
         return entityManager;
     }
@@ -198,6 +201,7 @@ public final class DaoHelper<TT> implements com.flowlogix.api.dao.DaoHelper<TT>,
      * @param resultClass {@link EntityManager#createNativeQuery(String, Class)}
      * @return {@link TypedNativeQuery}
      */
+    @Override
     public TypedNativeQuery createNativeQuery(String sql, Class<?> resultClass) {
         Query q = em().createNativeQuery(sql, resultClass);
         return new TypedNativeQuery(q);
@@ -212,6 +216,7 @@ public final class DaoHelper<TT> implements com.flowlogix.api.dao.DaoHelper<TT>,
      * @param resultMapping {@link EntityManager#createNativeQuery(String, String)}
      * @return {@link TypedNativeQuery}
      */
+    @Override
     public TypedNativeQuery createNativeQuery(String sql, String resultMapping) {
         Query q = em().createNativeQuery(sql, resultMapping);
         return new TypedNativeQuery(q);

--- a/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/jeedao/DaoHelper.java
+++ b/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/jeedao/DaoHelper.java
@@ -60,40 +60,32 @@ public final class DaoHelper<TT> implements JPANativeQuery<TT>, Serializable {
         this.entityClass = entityClass;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public TypedQuery<TT> findAll() {
         return findAll(null);
     }
 
     /**
-     * find all with enriched criteria
-     * <p>
-     * Example:
-     * <p>
-     * {@code findAll(builder -> builder.build())}
-     * <p>
-     * {@snippet class = "com.flowlogix.demo.jeedao.UserDAO" region = "daoParameters"}
-     *
-     * @param queryCriteria
-     * @return query
+     * {@inheritDoc}
      */
     @Override
     public TypedQuery<TT> findAll(Consumer<QueryCriteria<TT>> queryCriteria) {
         return createFindQuery(queryCriteria);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public TypedQuery<TT> findRange(long min, long max) {
         return findRange(min, max, null);
     }
 
     /**
-     * find range with enriched criteria
-     *
-     * @param min
-     * @param max
-     * @param queryCriteria
-     * @return query
+     * {@inheritDoc}
      */
     @Override
     public TypedQuery<TT> findRange(long min, long max, Consumer<QueryCriteria<TT>> queryCriteria) {
@@ -104,8 +96,7 @@ public final class DaoHelper<TT> implements JPANativeQuery<TT>, Serializable {
     }
 
     /**
-     * count rows
-     * @return row count
+     * {@inheritDoc}
      */
     @Override
     public long count() {
@@ -113,9 +104,7 @@ public final class DaoHelper<TT> implements JPANativeQuery<TT>, Serializable {
     }
 
     /**
-     * count with enriched criteria
-     * @param countQueryCriteria
-     * @return row count
+     * {@inheritDoc}
      */
     @Override
     public long count(Consumer<CountQueryCriteria<TT>> countQueryCriteria) {

--- a/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/jeedao/DaoHelper.java
+++ b/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/jeedao/DaoHelper.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import com.flowlogix.api.dao.JPAFinder;
-import com.flowlogix.api.dao.JPAFinderNative;
+import com.flowlogix.api.dao.JPANativeQuery;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
 import jakarta.persistence.TypedQuery;
@@ -45,7 +45,7 @@ import static java.lang.Math.toIntExact;
  *
  * @param <TT>
  */
-public final class DaoHelper<TT> implements JPAFinderNative<TT>, Serializable {
+public final class DaoHelper<TT> implements JPANativeQuery<TT>, Serializable {
     private static final long serialVersionUID = 5L;
 
     /**

--- a/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/jeedao/DaoHelperProducer.java
+++ b/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/jeedao/DaoHelperProducer.java
@@ -23,10 +23,11 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.ParameterizedType;
 import java.util.Arrays;
 import java.util.List;
+import com.flowlogix.api.dao.JPAFinder;
 import static com.flowlogix.jeedao.DaoHelper.findEntityManager;
 
 /**
- * Enables CDI Injection of DaoHelper
+ * Enables CDI Injection of {@link JPAFinder} instances
  */
 @Dependent
 @SuppressWarnings("HideUtilityClassConstructor")

--- a/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/jeedao/InheritableDaoHelper.java
+++ b/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/jeedao/InheritableDaoHelper.java
@@ -27,7 +27,7 @@ import lombok.experimental.Delegate;
  * <p>
  * {@snippet class="com.flowlogix.demo.jeedao.InheritedDAO" region="inheritedDAO"}
  *
- * @see DaoHelper
+ * @see JPAFinder
  * @param <TT> Entity Type
  */
 public class InheritableDaoHelper<TT> implements Serializable {

--- a/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/jeedao/InheritableDaoHelper.java
+++ b/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/jeedao/InheritableDaoHelper.java
@@ -16,12 +16,14 @@
 package com.flowlogix.jeedao;
 
 import java.io.Serializable;
+import com.flowlogix.api.dao.JPAFinder;
+import com.flowlogix.api.dao.JPAFinderHelper;
 import lombok.experimental.Delegate;
 
 /**
  * Data Access Object pattern implementation that is meant to be inherited by the user's classes.
- * This is an alternative to {@link DaoHelper}, which does not have requirements
- * for inheritance. {@link DaoHelper} is the preferred method of implementing DAOs.
+ * This is an alternative to {@link JPAFinder}, which does not have requirements
+ * for inheritance. {@link JPAFinder} is the preferred method of implementing DAOs.
  * <p>
  * {@snippet class="com.flowlogix.demo.jeedao.InheritedDAO" region="inheritedDAO"}
  *
@@ -32,5 +34,5 @@ public class InheritableDaoHelper<TT> implements Serializable {
     private static final long serialVersionUID = 4L;
 
     @Delegate
-    protected DaoHelper<TT> daoHelper;
+    protected JPAFinderHelper<TT> jpaFinder;
 }

--- a/jakarta-ee/flowlogix-jee/src/test/java/com/flowlogix/jeedao/FacadeTest.java
+++ b/jakarta-ee/flowlogix-jee/src/test/java/com/flowlogix/jeedao/FacadeTest.java
@@ -118,8 +118,8 @@ public class FacadeTest implements Serializable {
     @SuppressWarnings("unchecked")
     void inheritableDao() {
         InheritableDaoHelper<Integer> helper = new InheritableDaoHelper<>();
-        assertNull(helper.daoHelper);
-        helper.daoHelper = DaoHelper.<Integer>builder()
+        assertNull(helper.jpaFinder);
+        helper.jpaFinder = DaoHelper.<Integer>builder()
                 .entityManager(() -> em)
                 .entityClass(Integer.class)
                 .build();

--- a/jakarta-ee/jee-examples/pom.xml
+++ b/jakarta-ee/jee-examples/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.flowlogix</groupId>
     <artifactId>jee-examples</artifactId>
-    <version>8.x-SNAPSHOT</version>
+    <version>9.x-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>JEE Services and PrimeFaces Examples</name>
 
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.flowlogix</groupId>
         <artifactId>flowlogix</artifactId>
-        <version>8.x-SNAPSHOT</version>
+        <version>9.x-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/jakarta-ee/pom.xml
+++ b/jakarta-ee/pom.xml
@@ -4,14 +4,14 @@
 
     <groupId>com.flowlogix</groupId>
     <artifactId>jakarta-ee</artifactId>
-    <version>8.x-SNAPSHOT</version>
+    <version>9.x-SNAPSHOT</version>
     <name>FlowLogix Jakarta EE Modules</name>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.flowlogix</groupId>
         <artifactId>flowlogix-bom</artifactId>
-        <version>8.x-SNAPSHOT</version>
+        <version>9.x-SNAPSHOT</version>
         <relativePath>../flowlogix-bom</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>flowlogix</artifactId>
-    <version>8.x-SNAPSHOT</version>
+    <version>9.x-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Flow Logix Root</name>
     <description>Flow Logix Jakarta EE Components Root POM</description>


### PR DESCRIPTION
- Splits up DAO API
- Removes builders
- Simplifies `find()` / `count()` APIs dramatically

Status: 
- [x] First pass
- [x] builder -> records -> nothing
- [x] another interface for native query
- [x] Injectable impl / Alternative (nothing to do)
- [x] Javadoc
- [x] Docs
- [x] General cleanup

fixes #689