### PR TITLE
chore: sslPort -> httpsPort

### DIFF
--- a/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/util/ShrinkWrapManipulator.java
+++ b/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/util/ShrinkWrapManipulator.java
@@ -89,7 +89,7 @@ public class ShrinkWrapManipulator {
         }
     }
 
-    static final String DEFAULT_SSL_PROPERTY = "sslPort";
+    static final String DEFAULT_SSL_PROPERTY = "httpsPort";
     static final int DEFAULT_SSL_PORT = 8181;
 
     final Lazy<DocumentBuilder> builder = new Lazy<>(this::createDocumentBuilder);

--- a/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/util/ShrinkWrapManipulator.java
+++ b/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/util/ShrinkWrapManipulator.java
@@ -247,6 +247,10 @@ public class ShrinkWrapManipulator {
             return httpUrl;
         }
         int sslPort = Integer.getInteger(sslPortPropertyName, defaultPort);
+        // try the backup system proper
+        if (sslPort == defaultPort) {
+            sslPort = Integer.getInteger("sslPort", defaultPort);
+        }
         return new URI(httpUrl.getProtocol() + "s", null, httpUrl.getHost(), sslPort,
                 httpUrl.getPath(), null, null).toURL();
     }


### PR DESCRIPTION
Changed system property for port number for SSL to represent standardized port `httpsPort`
Using the old value of `sslPort` as a backup