### PR TITLE
enh: Remove hardcoded default http port of 8181

### DIFF
--- a/jakarta-ee/flowlogix-jee/pom.xml
+++ b/jakarta-ee/flowlogix-jee/pom.xml
@@ -83,6 +83,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <httpsPort>${payara.https.port}</httpsPort>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/util/ShrinkWrapManipulator.java
+++ b/jakarta-ee/flowlogix-jee/src/main/java/com/flowlogix/util/ShrinkWrapManipulator.java
@@ -90,7 +90,6 @@ public class ShrinkWrapManipulator {
     }
 
     static final String DEFAULT_SSL_PROPERTY = "httpsPort";
-    static final int DEFAULT_SSL_PORT = 8181;
 
     final Lazy<DocumentBuilder> builder = new Lazy<>(this::createDocumentBuilder);
     final Lazy<Transformer> transformer = new Lazy<>(this::createTransformer);
@@ -229,7 +228,7 @@ public class ShrinkWrapManipulator {
      */
     @SuppressWarnings("MagicNumber")
     public static URL toHttpsURL(URL httpUrl) {
-        return toHttpsURL(httpUrl, DEFAULT_SSL_PROPERTY, DEFAULT_SSL_PORT);
+        return toHttpsURL(httpUrl, DEFAULT_SSL_PROPERTY, -1);
     }
 
     /**

--- a/jakarta-ee/flowlogix-jee/src/test/java/com/flowlogix/util/ShrinkWrapManipulatorTest.java
+++ b/jakarta-ee/flowlogix-jee/src/test/java/com/flowlogix/util/ShrinkWrapManipulatorTest.java
@@ -36,7 +36,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URI;
-import static com.flowlogix.util.ShrinkWrapManipulator.DEFAULT_SSL_PORT;
 import static com.flowlogix.util.ShrinkWrapManipulator.DEFAULT_SSL_PROPERTY;
 import static com.flowlogix.util.ShrinkWrapManipulator.runActionOnNode;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -267,7 +266,8 @@ class ShrinkWrapManipulatorTest {
         assertThat(ShrinkWrapManipulator.getLogger()).isNotNull();
     }
 
+    @SuppressWarnings("checkstyle:MagicNumber")
     private static int getPortFromProperty() {
-        return Integer.parseInt(System.getProperty(DEFAULT_SSL_PROPERTY, String.valueOf(DEFAULT_SSL_PORT)));
+        return Integer.parseInt(System.getProperty(DEFAULT_SSL_PROPERTY, String.valueOf(8181)));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,14 @@
                     </configuration>
                 </plugin>
                 <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <configuration>
+                        <systemPropertyVariables>
+                            <httpsPort>${payara.https.port}</httpsPort>
+                        </systemPropertyVariables>
+                    </configuration>
+                </plugin>
+                <plugin>
                     <artifactId>maven-failsafe-plugin</artifactId>
                     <configuration>
                         <systemPropertyVariables>

--- a/pom.xml
+++ b/pom.xml
@@ -156,14 +156,6 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <configuration>
-                        <systemPropertyVariables>
-                            <httpsPort>${payara.https.port}</httpsPort>
-                        </systemPropertyVariables>
-                    </configuration>
-                </plugin>
-                <plugin>
                     <artifactId>maven-failsafe-plugin</artifactId>
                     <configuration>
                         <systemPropertyVariables>


### PR DESCRIPTION
Will go into payara-pom.
This way toHttpsURL() will return no-port by default, working better out-of-the-box