### PR TITLE
[Enhancement] Don't require serialized entities

### DIFF
--- a/flowlogix-datamodel/src/main/java/com/flowlogix/jeedao/primefaces/JPALazyDataModel.java
+++ b/flowlogix-datamodel/src/main/java/com/flowlogix/jeedao/primefaces/JPALazyDataModel.java
@@ -21,6 +21,7 @@ import com.flowlogix.jeedao.primefaces.internal.JPAModelImpl.JPAModelImplBuilder
 import com.flowlogix.jeedao.primefaces.internal.InternalQualifierJPALazyModel;
 import java.io.Serial;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -204,9 +205,7 @@ public class JPALazyDataModel<TT> extends LazyDataModel<TT> {
     @SuppressWarnings("unchecked")
     public void setWrappedData(Object wrappedData) {
         data = (List<TT>) wrappedData;
-        if (data != null && !data.isEmpty()) {
-            super.setWrappedData(List.of());
-        }
+        super.setWrappedData(data == null ? null : List.of());
     }
 
     @Override

--- a/flowlogix-datamodel/src/main/java/com/flowlogix/jeedao/primefaces/JPALazyDataModel.java
+++ b/flowlogix-datamodel/src/main/java/com/flowlogix/jeedao/primefaces/JPALazyDataModel.java
@@ -19,9 +19,6 @@ import com.flowlogix.jeedao.primefaces.internal.JPAModelImpl;
 import com.flowlogix.jeedao.primefaces.internal.JPAModelImpl.BuilderInitializer;
 import com.flowlogix.jeedao.primefaces.internal.JPAModelImpl.JPAModelImplBuilder;
 import com.flowlogix.jeedao.primefaces.internal.InternalQualifierJPALazyModel;
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 import java.io.Serial;
 import java.io.Serializable;
 import java.util.List;
@@ -77,15 +74,8 @@ public class JPALazyDataModel<TT> extends LazyDataModel<TT> {
     private static final long serialVersionUID = 5L;
     @Delegate
     private JPAModelImpl<TT> impl;
-    private CachedQuery cachedQuery;
+    private transient List<TT> data;
     private transient PartialBuilderConsumer<TT> partialBuilder;
-    private transient boolean deserializedButNotInitialized;
-
-    private record CachedQuery(int first, Map<String, SortMeta> sortBy, Map<String, FilterMeta> filterBy)
-            implements Serializable {
-        @Serial
-        private static final long serialVersionUID = 1L;
-    }
 
     /**
      * Prevent direct creation
@@ -181,7 +171,6 @@ public class JPALazyDataModel<TT> extends LazyDataModel<TT> {
     @Override
     @Transactional
     public List<TT> load(int first, int pageSize, Map<String, SortMeta> sortBy, Map<String, FilterMeta> filterBy) {
-        cachedQuery = new CachedQuery(first, sortBy, filterBy);
         return impl.findRows(first, pageSize, filterBy, sortBy);
     }
 
@@ -195,19 +184,28 @@ public class JPALazyDataModel<TT> extends LazyDataModel<TT> {
 
     @Override
     public boolean isRowAvailable() {
-        initializeData();
-        return super.isRowAvailable();
+        initializeData(getPageSize(), this);
+        return getRowIndex() >= 0 && getRowCount() < data.size();
     }
 
     @Override
     public List<TT> getWrappedData() {
-        initializeData();
-        return super.getWrappedData();
+        initializeData(getPageSize(), this);
+        return data;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void setWrappedData(Object wrappedData) {
+        data = (List<TT>) wrappedData;
+        if (data != null && !data.isEmpty()) {
+            super.setWrappedData(List.of());
+        }
     }
 
     @Override
     public void setRowIndex(int rowIndex) {
-        initializeData();
+        initializeData(getPageSize(), this);
         super.setRowIndex(rowIndex);
     }
 
@@ -218,34 +216,5 @@ public class JPALazyDataModel<TT> extends LazyDataModel<TT> {
             partialBuilder = null;
         }
         return this;
-    }
-
-    private void initializeData() {
-        if (deserializedButNotInitialized) {
-            if (cachedQuery != null) {
-                setWrappedData(impl.findRows(cachedQuery.first, getPageSize(), cachedQuery.filterBy, cachedQuery.sortBy));
-            }
-            deserializedButNotInitialized = false;
-        }
-    }
-
-    @Serial
-    @SuppressWarnings("unchecked")
-    private void readObject(ObjectInputStream stream) throws IOException, ClassNotFoundException {
-        deserializedButNotInitialized = true;
-        setRowCount(stream.readInt());
-        setPageSize(stream.readInt());
-        super.setRowIndex(stream.readInt());
-        impl = (JPAModelImpl<TT>) stream.readObject();
-        cachedQuery = (CachedQuery) stream.readObject();
-    }
-
-    @Serial
-    private void writeObject(ObjectOutputStream stream) throws IOException {
-        stream.writeInt(getRowCount());
-        stream.writeInt(getPageSize());
-        stream.writeInt(getRowIndex());
-        stream.writeObject(impl);
-        stream.writeObject(cachedQuery);
     }
 }

--- a/flowlogix-datamodel/src/main/java/com/flowlogix/jeedao/primefaces/JPALazyDataModel.java
+++ b/flowlogix-datamodel/src/main/java/com/flowlogix/jeedao/primefaces/JPALazyDataModel.java
@@ -183,9 +183,15 @@ public class JPALazyDataModel<TT> extends LazyDataModel<TT> {
     }
 
     @Override
+    public TT getRowData() {
+        initializeData(getPageSize(), this);
+        return data.get(getRowIndex());
+    }
+
+    @Override
     public boolean isRowAvailable() {
         initializeData(getPageSize(), this);
-        return getRowIndex() >= 0 && getRowCount() < data.size();
+        return getRowIndex() >= 0 && getRowIndex() < data.size();
     }
 
     @Override

--- a/flowlogix-datamodel/src/main/java/com/flowlogix/jeedao/primefaces/JPALazyDataModel.java
+++ b/flowlogix-datamodel/src/main/java/com/flowlogix/jeedao/primefaces/JPALazyDataModel.java
@@ -21,7 +21,6 @@ import com.flowlogix.jeedao.primefaces.internal.JPAModelImpl.JPAModelImplBuilder
 import com.flowlogix.jeedao.primefaces.internal.InternalQualifierJPALazyModel;
 import java.io.Serial;
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;

--- a/flowlogix-datamodel/src/main/java/com/flowlogix/jeedao/primefaces/JPALazyDataModel.java
+++ b/flowlogix-datamodel/src/main/java/com/flowlogix/jeedao/primefaces/JPALazyDataModel.java
@@ -19,6 +19,10 @@ import com.flowlogix.jeedao.primefaces.internal.JPAModelImpl;
 import com.flowlogix.jeedao.primefaces.internal.JPAModelImpl.BuilderInitializer;
 import com.flowlogix.jeedao.primefaces.internal.JPAModelImpl.JPAModelImplBuilder;
 import com.flowlogix.jeedao.primefaces.internal.InternalQualifierJPALazyModel;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
@@ -69,10 +73,19 @@ public class JPALazyDataModel<TT> extends LazyDataModel<TT> {
      * and can be used with {@link #getResultField(String)} for result fields
      */
     public static final String RESULT = "result";
-    private static final long serialVersionUID = 4L;
+    @Serial
+    private static final long serialVersionUID = 5L;
     @Delegate
     private JPAModelImpl<TT> impl;
+    private CachedQuery cachedQuery;
     private transient PartialBuilderConsumer<TT> partialBuilder;
+    private transient boolean deserializedButNotInitialized;
+
+    private record CachedQuery(int first, Map<String, SortMeta> sortBy, Map<String, FilterMeta> filterBy)
+            implements Serializable {
+        @Serial
+        private static final long serialVersionUID = 1L;
+    }
 
     /**
      * Prevent direct creation
@@ -179,6 +192,24 @@ public class JPALazyDataModel<TT> extends LazyDataModel<TT> {
         return impl.count(map);
     }
 
+    @Override
+    public boolean isRowAvailable() {
+        initializeData();
+        return super.isRowAvailable();
+    }
+
+    @Override
+    public List<TT> getWrappedData() {
+        initializeData();
+        return super.getWrappedData();
+    }
+
+    @Override
+    public void setRowIndex(int rowIndex) {
+        initializeData();
+        super.setRowIndex(rowIndex);
+    }
+
     private JPALazyDataModel<TT> initialize(BuilderFunction<TT> builder, boolean resetPartialBuilder) {
         impl = JPAModelImpl.create(new BuilderInitializer<>(builder, partialBuilder));
         impl.setX_do_not_use_in_builder(new BuilderInitializer<>(builder, partialBuilder));
@@ -186,5 +217,34 @@ public class JPALazyDataModel<TT> extends LazyDataModel<TT> {
             partialBuilder = null;
         }
         return this;
+    }
+
+    private void initializeData() {
+        if (deserializedButNotInitialized) {
+            if (cachedQuery != null) {
+                setWrappedData(impl.findRows(cachedQuery.first, getPageSize(), cachedQuery.filterBy, cachedQuery.sortBy));
+            }
+            deserializedButNotInitialized = false;
+        }
+    }
+
+    @Serial
+    @SuppressWarnings("unchecked")
+    private void readObject(ObjectInputStream stream) throws IOException, ClassNotFoundException {
+        deserializedButNotInitialized = true;
+        setRowCount(stream.readInt());
+        setPageSize(stream.readInt());
+        super.setRowIndex(stream.readInt());
+        impl = (JPAModelImpl<TT>) stream.readObject();
+        cachedQuery = (CachedQuery) stream.readObject();
+    }
+
+    @Serial
+    private void writeObject(ObjectOutputStream stream) throws IOException {
+        stream.writeInt(getRowCount());
+        stream.writeInt(getPageSize());
+        stream.writeInt(getRowIndex());
+        stream.writeObject(impl);
+        stream.writeObject(cachedQuery);
     }
 }

--- a/flowlogix-datamodel/src/main/java/com/flowlogix/jeedao/primefaces/JPALazyDataModel.java
+++ b/flowlogix-datamodel/src/main/java/com/flowlogix/jeedao/primefaces/JPALazyDataModel.java
@@ -181,6 +181,7 @@ public class JPALazyDataModel<TT> extends LazyDataModel<TT> {
     @Override
     @Transactional
     public List<TT> load(int first, int pageSize, Map<String, SortMeta> sortBy, Map<String, FilterMeta> filterBy) {
+        cachedQuery = new CachedQuery(first, sortBy, filterBy);
         return impl.findRows(first, pageSize, filterBy, sortBy);
     }
 

--- a/flowlogix-datamodel/src/main/java/com/flowlogix/jeedao/primefaces/internal/JPAModelImpl.java
+++ b/flowlogix-datamodel/src/main/java/com/flowlogix/jeedao/primefaces/internal/JPAModelImpl.java
@@ -595,6 +595,7 @@ public class JPAModelImpl<TT> implements Serializable {
     Object readResolve() throws ObjectStreamException {
         var corrected = create(x_do_not_use_in_builder);
         corrected.x_do_not_use_in_builder = x_do_not_use_in_builder;
+        corrected.cachedQuery = cachedQuery;
         corrected.deserializedButNotInitialized = true;
         return corrected;
     }

--- a/flowlogix-datamodel/src/main/java/com/flowlogix/jeedao/primefaces/internal/JPAModelImpl.java
+++ b/flowlogix-datamodel/src/main/java/com/flowlogix/jeedao/primefaces/internal/JPAModelImpl.java
@@ -31,6 +31,7 @@ import com.flowlogix.jeedao.primefaces.Sorter.SortData;
 import com.flowlogix.util.TypeConverter;
 import jakarta.persistence.criteria.Join;
 import java.io.ObjectStreamException;
+import java.io.Serial;
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.util.ArrayDeque;
@@ -88,7 +89,18 @@ import org.primefaces.util.Constants;
 @Builder
 @SuppressWarnings("checkstyle:ClassFanOutComplexity")
 public class JPAModelImpl<TT> implements Serializable {
-    private static final long serialVersionUID = 6L;
+    @Serial
+    private static final long serialVersionUID = 7L;
+
+    private CachedQuery cachedQuery;
+    private transient boolean deserializedButNotInitialized;
+
+    private record CachedQuery(int first, Map<String, SortMeta> sortBy, Map<String, FilterMeta> filterBy)
+            implements Serializable {
+        @Serial
+        private static final long serialVersionUID = 1L;
+    }
+
     /**
      * Return entity manager to operate on
      */
@@ -220,6 +232,7 @@ public class JPAModelImpl<TT> implements Serializable {
         if (cursorSupported && !result.isEmpty()) {
             cursor.get().save(sanitizedFirst + result.size(), result.get(result.size() - 1), sortMeta);
         }
+        cachedQuery = new CachedQuery(first, sortMeta, filters);
         return result;
     }
 
@@ -328,6 +341,15 @@ public class JPAModelImpl<TT> implements Serializable {
             }
         }
         return join == null ? root.get(fieldName) : join.get(fieldName);
+    }
+
+    public void initializeData(int pageSize, JPALazyDataModel<TT> model) {
+        if (deserializedButNotInitialized) {
+            if (cachedQuery != null) {
+                model.setWrappedData(findRows(cachedQuery.first, pageSize, cachedQuery.filterBy, cachedQuery.sortBy));
+            }
+            deserializedButNotInitialized = false;
+        }
     }
 
     private FilterMetaResult processFilterMeta(CriteriaBuilder cb, Root<TT> root, String key, FilterMeta filterMeta) {
@@ -573,6 +595,7 @@ public class JPAModelImpl<TT> implements Serializable {
     Object readResolve() throws ObjectStreamException {
         var corrected = create(x_do_not_use_in_builder);
         corrected.x_do_not_use_in_builder = x_do_not_use_in_builder;
+        corrected.deserializedButNotInitialized = true;
         return corrected;
     }
 }

--- a/flowlogix-datamodel/src/test/java/com/flowlogix/jeedao/primefaces/ModelTest.java
+++ b/flowlogix-datamodel/src/test/java/com/flowlogix/jeedao/primefaces/ModelTest.java
@@ -503,4 +503,15 @@ class ModelTest implements Serializable {
         assertThatExceptionOfType(NullPointerException.class)
                 .isThrownBy(() -> JPAModelImpl.create(null));
     }
+
+    @Test
+    void wrappedData() {
+        var model = new JPALazyDataModel<Integer>().initialize(builder -> builder
+                .entityClass(Integer.class).entityManager(() -> em).build());
+        model.setWrappedData(List.of(1, 2, 3));
+        model.setRowIndex(5);
+        assertThat(model.getWrappedData()).size().isEqualTo(3);
+        model.setWrappedData(null);
+        assertThat(model.getWrappedData()).isNull();
+    }
 }

--- a/flowlogix-datamodel/src/test/java/com/flowlogix/jeedao/primefaces/ModelTest.java
+++ b/flowlogix-datamodel/src/test/java/com/flowlogix/jeedao/primefaces/ModelTest.java
@@ -416,6 +416,24 @@ class ModelTest implements Serializable {
                 .getIdentifier(any(MyEntity.class))).thenReturn(5L);
         var deserialized = serializeAndDeserialize(model);
         assertThat(deserialized.getRowKey(new MyEntity())).isEqualTo("5");
+        assertThat(deserialized.getWrappedData()).isNull();
+    }
+
+    @Test
+    void serializationWithCachedQuery() throws IOException, ClassNotFoundException {
+        JPALazyDataModel<MyEntity> model;
+        try (var mockedStatic = mockStatic(Beans.class, withSettings().defaultAnswer(RETURNS_DEEP_STUBS))) {
+            mockedStatic.when(() -> Beans.getReference(eq(JPALazyDataModel.class), eq(InternalQualifierJPALazyModel.LITERAL)))
+                    .thenReturn(new JPALazyDataModel<>());
+            model = JPALazyDataModel.create(builder -> builder
+                    .entityManager(() -> em).entityClass(MyEntity.class)
+                    .build());
+        }
+        lenient().when(em.getEntityManagerFactory().getPersistenceUnitUtil()
+                .getIdentifier(any(MyEntity.class))).thenReturn(5L);
+        model.findRows(0, 10, Map.of(), Map.of());
+        var deserialized = serializeAndDeserialize(model);
+        assertThat(deserialized.getWrappedData()).isEmpty();
     }
 
     @Test

--- a/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/entities/AlternateEmails.java
+++ b/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/entities/AlternateEmails.java
@@ -22,7 +22,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrimaryKeyJoinColumn;
 import jakarta.validation.constraints.Size;
-import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -38,8 +37,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class AlternateEmails implements Serializable {
-    private static final long serialVersionUID = 1L;
+public class AlternateEmails {
     @Id
     @GeneratedValue
     private Long id;

--- a/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/entities/UserEntity.java
+++ b/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/entities/UserEntity.java
@@ -20,7 +20,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OrderBy;
 import jakarta.persistence.PostPersist;
-import java.io.Serializable;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
@@ -42,8 +41,7 @@ import lombok.ToString;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class UserEntity implements Serializable {
-    private static final long serialVersionUID = 2L;
+public class UserEntity {
     @Id
     @GeneratedValue
     private Long id;

--- a/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/entities/UserSettings.java
+++ b/flowlogix-jee/src/demo/java/com/flowlogix/demo/jeedao/entities/UserSettings.java
@@ -22,7 +22,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrimaryKeyJoinColumn;
 import jakarta.validation.constraints.Size;
-import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -38,8 +37,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class UserSettings implements Serializable {
-    private static final long serialVersionUID = 1L;
+public class UserSettings {
     @Id
     @GeneratedValue
     private Long id;

--- a/src/checkstyle/suppressions.xml
+++ b/src/checkstyle/suppressions.xml
@@ -37,7 +37,7 @@
     <suppress checks="JavadocType" files="JPAModelImpl" lines="84,166,203"/>
     <suppress checks="OuterTypeNumber" files="CursorPagination" lines="16"/>
     <suppress checks="JavadocType" files="CursorPagination" lines="141"/>
-    <suppress checks="JavadocType" files="JPALazyDataModel.java" lines="132"/>
+    <suppress checks="JavadocType" files="JPALazyDataModel.java" lines="145"/>
 
     <suppress checks="JavadocVariable" lines="49-52" files="com.flowlogix.util.ShrinkWrapManipulator"/>
     <suppress checks="ConstantName" lines="60-63" files="com.flowlogix.util.TypeConverter"/>

--- a/src/checkstyle/suppressions.xml
+++ b/src/checkstyle/suppressions.xml
@@ -34,10 +34,10 @@
     <suppress checks="JavadocPackage" files="com.flowlogix.examples.*"/>
     <suppress checks="JavadocType" files="PackageMarker"/>
     <suppress checks="JavadocType" files="InternalQualifierJPALazyModel" lines="26"/>
-    <suppress checks="JavadocType" files="JPAModelImpl" lines="84,166,203"/>
+    <suppress checks="JavadocType" files="JPAModelImpl" lines="85,178,215"/>
     <suppress checks="OuterTypeNumber" files="CursorPagination" lines="16"/>
     <suppress checks="JavadocType" files="CursorPagination" lines="141"/>
-    <suppress checks="JavadocType" files="JPALazyDataModel.java" lines="145"/>
+    <suppress checks="JavadocType" files="JPALazyDataModel.java" lines="135"/>
 
     <suppress checks="JavadocVariable" lines="49-52" files="com.flowlogix.util.ShrinkWrapManipulator"/>
     <suppress checks="ConstantName" lines="60-63" files="com.flowlogix.util.TypeConverter"/>


### PR DESCRIPTION
Don't require entities to be serializable to be usable in JPA Lazy DataModel
fixes #1572

TODO:
- [x] testing
- [x] code coverate